### PR TITLE
Update repo naming and links after changing from 'ckeditor-dev' to 'ckeditor4' etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,38 @@
 Code samples for CKEditor documentation
 =====================
 
-This repository contains ready-to-use code samples created for the [CKEditor 4 documentation](https://docs.ckeditor.com/ckeditor4/docs/) and [website](https://ckeditor.com/ckeditor-4/).
+This repository contains ready-to-use code samples created for the [CKEditor 4 documentation](https://ckeditor.com/docs/ckeditor4/latest/index.html) and [website](https://ckeditor.com/ckeditor-4/).
 
 In order to see a sample in action, copy its source to the CKEditor `plugins` directory.
 
-1. Download a CKEditor package. Note that for development purposes it is recommended to download the source version. You can do this by downloading [your own CKEditor build](https://ckeditor.com/cke4/builder) (note the sample's requirements) and checking the "Source (Big N’Slow)" option at the bottom. You can also clone the [CKEditor development repository](https://github.com/ckeditor/ckeditor-dev) and proceed from there.
+1. Download a CKEditor package. Note that for development purposes it is recommended to download the source version. You can do this by downloading [your own CKEditor build](https://ckeditor.com/cke4/builder) (note the sample's requirements) and checking the "Source (Big N’Slow)" option at the bottom. You can also clone the [CKEditor development repository](https://github.com/ckeditor/ckeditor4) and proceed from there.
 
 2. Copy the plugin directory which you can find in every sample to the `plugins` directory in the installed CKEditor package.
 
 For example:
 
     # Clone the CKEditor development repository and this repository with samples.
-    git clone https://github.com/ckeditor/ckeditor-dev.git
-    git clone https://github.com/ckeditor/ckeditor-docs-samples.git
+    git clone https://github.com/ckeditor/ckeditor4.git
+    git clone https://github.com/ckeditor/ckeditor4-docs-samples.git
 
     # Checkout the latest stable branch (equals to latest release available on https://ckeditor.com/ckeditor-4/download/).
-    cd ckeditor-dev
+    cd ckeditor4
     git co stable
     cd ..
 
     # Enter one of samples directory.
-    cd ckeditor-docs-samples/tutorial-simplebox-1/
+    cd ckeditor4-docs-samples/tutorial-simplebox-1/
 
     # Copy plugin directory to CKEditor directory.
-    cp -R simplebox/ ../../ckeditor-dev/plugins/
+    cp -R simplebox/ ../../ckeditor4/plugins/
 
 Now open the plugin sample in your browser. The URL will look like:
 
     http://<your-host>/<ckeditor-package-path>/plugins/simplebox/samples/simplebox.html
 
     For example:
-    http://localhost/ckeditor-dev/plugins/simplebox/samples/simplebox.html
-    
+    http://localhost/ckeditor4/plugins/simplebox/samples/simplebox.html
+
 License
 -------
-For license details see: [LICENSE.md](https://github.com/ckeditor/ckeditor-docs-samples/blob/master/LICENSE.md).
+For license details see: [LICENSE.md](https://github.com/ckeditor/ckeditor4-docs-samples/blob/master/LICENSE.md).

--- a/editors/article-editor/index.html
+++ b/editors/article-editor/index.html
@@ -35,7 +35,7 @@
 </div>
 <script>
 	CKEDITOR.replace( 'editor1', {
-		// Define the toolbar: http://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_toolbar
+		// Define the toolbar: https://ckeditor.com/docs/ckeditor4/latest/features/toolbar.html
 		// The standard preset from CDN which we used as a base provides more features than we need.
 		// Also by default it comes with a 2-line toolbar. Here we put all buttons in a single row.
 		toolbar: [
@@ -51,16 +51,16 @@
 
 		// Since we define all configuration options here, let's instruct CKEditor to not load config.js which it does by default.
 		// One HTTP request less will result in a faster startup time.
-		// For more information check http://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-customConfig
+		// For more information check https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-customConfig
 		customConfig: '',
 
-		// Enabling extra plugins, available in the standard-all preset: http://ckeditor.com/presets-all
+		// Enabling extra plugins, available in the standard-all preset: https://ckeditor.com/cke4/presets-all
 		extraPlugins: 'autoembed,embedsemantic,image2,uploadimage,uploadfile',
 
 		/*********************** File management support ***********************/
 		// In order to turn on support for file uploads, CKEditor has to be configured to use some server side
 		// solution with file upload/management capabilities, like for example CKFinder.
-		// For more information see http://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_ckfinder_integration
+		// For more information see https://ckeditor.com/docs/ckeditor4/latest/guide/dev_ckfinder_integration.html
 
 		// Uncomment and correct these lines after you setup your local CKFinder instance.
 		// filebrowserBrowseUrl: 'http://example.com/ckfinder/ckfinder.html',
@@ -91,7 +91,7 @@
 		// (and on your website so that it rendered in the same way).
 		// Note: by default CKEditor looks for styles.js file. Defining stylesSet inline (as below) stops CKEditor from loading
 		// that file, which means one HTTP request less (and a faster startup).
-		// For more information see http://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_styles
+		// For more information see https://ckeditor.com/docs/ckeditor4/latest/features/styles.html
 		stylesSet: [
 			/* Inline Styles */
 			{ name: 'Marker',			element: 'span', attributes: { 'class': 'marker' } },

--- a/editors/document-editor/index.html
+++ b/editors/document-editor/index.html
@@ -62,7 +62,7 @@
 </div>
 <script>
 	CKEDITOR.replace( 'editor1', {
-		// Define the toolbar: http://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_toolbar
+		// Define the toolbar: https://ckeditor.com/docs/ckeditor4/latest/features/toolbar.html
 		// The full preset from CDN which we used as a base provides more features than we need.
 		// Also by default it comes with a 3-line toolbar. Here we put all buttons in a single row.
 		toolbar: [
@@ -81,24 +81,24 @@
 
 		// Since we define all configuration options here, let's instruct CKEditor to not load config.js which it does by default.
 		// One HTTP request less will result in a faster startup time.
-		// For more information check http://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-customConfig
+		// For more information check https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-customConfig
 		customConfig: '',
 
 		// Sometimes applications that convert HTML to PDF prefer setting image width through attributes instead of CSS styles.
 		// For more information check:
-		//  - About Advanced Content Filter: http://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_advanced_content_filter
-		//  - About Disallowed Content: http://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_disallowed_content
-		//  - About Allowed Content: http://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_allowed_content_rules
+		//  - About Advanced Content Filter: https://ckeditor.com/docs/ckeditor4/latest/guide/dev_advanced_content_filter.html
+		//  - About Disallowed Content: https://ckeditor.com/docs/ckeditor4/latest/guide/dev_disallowed_content.html
+		//  - About Allowed Content: https://ckeditor.com/docs/ckeditor4/latest/guide/dev_allowed_content_rules.html
 		disallowedContent: 'img{width,height,float}',
 		extraAllowedContent: 'img[width,height,align]',
 
-		// Enabling extra plugins, available in the full-all preset: http://ckeditor.com/presets-all
+		// Enabling extra plugins, available in the full-all preset: https://ckeditor.com/cke4/presets-all
 		extraPlugins: 'tableresize,uploadimage,uploadfile',
 
 		/*********************** File management support ***********************/
 		// In order to turn on support for file uploads, CKEditor has to be configured to use some server side
 		// solution with file upload/management capabilities, like for example CKFinder.
-		// For more information see http://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_ckfinder_integration
+		// For more information see https://ckeditor.com/docs/ckeditor4/latest/guide/dev_ckfinder_integration.html
 
 		// Uncomment and correct these lines after you setup your local CKFinder instance.
 		// filebrowserBrowseUrl: 'http://example.com/ckfinder/ckfinder.html',
@@ -126,7 +126,7 @@
 		// (and on your website so that it rendered in the same way).
 		// Note: by default CKEditor looks for styles.js file. Defining stylesSet inline (as below) stops CKEditor from loading
 		// that file, which means one HTTP request less (and a faster startup).
-		// For more information see http://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_styles
+		// For more information see https://ckeditor.com/docs/ckeditor4/latest/features/styles.html
 		stylesSet: [
 			/* Inline Styles */
 			{ name: 'Marker', element: 'span', attributes: { 'class': 'marker' } },

--- a/tutorial-abbr-1/abbr/dialogs/abbr.js
+++ b/tutorial-abbr-1/abbr/dialogs/abbr.js
@@ -5,7 +5,7 @@
  * The abbr plugin dialog window definition.
  *
  * Created out of the CKEditor Plugin SDK:
- * http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_sample_1
+ * https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample_1.html
  */
 
 // Our dialog definition.
@@ -64,7 +64,7 @@ CKEDITOR.dialog.add( 'abbrDialog', function( editor ) {
 		onOk: function() {
 
 			// The context of this function is the dialog object itself.
-			// http://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.dialog
+			// https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dialog.html
 			var dialog = this;
 
 			// Create a new <abbr> element.

--- a/tutorial-abbr-1/abbr/plugin.js
+++ b/tutorial-abbr-1/abbr/plugin.js
@@ -5,7 +5,7 @@
  * Basic sample plugin inserting abbreviation elements into the CKEditor editing area.
  *
  * Created out of the CKEditor Plugin SDK:
- * http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_sample_1
+ * https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample_1.html
  */
 
 // Register the plugin within the editor.

--- a/tutorial-abbr-1/abbr/samples/abbr.html
+++ b/tutorial-abbr-1/abbr/samples/abbr.html
@@ -17,7 +17,7 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 
 	<p>
 		This sample demonstrates the <strong>Abbreviation</strong> plugin that was created in the
-		<a href="http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_sample_1">first installment</a> of
+		<a href="https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample_1.html">first installment</a> of
 		of the CKEditor plugin tutorial series.
 	</p>
 
@@ -30,7 +30,7 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 	<p>
 		<strong>Note:</strong> This version of the Abbreviation plugin is able to add a new <code>&lt;abbr&gt;</code> element to the document,
 		but it does not make it possible to edit an already existing element. For this feature along with the context menu support check
-		the <a href="http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_sample_2">second part of the tutorial</a>.
+		the <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample_2.html">second part of the tutorial</a>.
 	</p>
 
 	<textarea id="editor1" cols="10" rows="10">

--- a/tutorial-abbr-2/abbr/dialogs/abbr.js
+++ b/tutorial-abbr-2/abbr/dialogs/abbr.js
@@ -5,7 +5,7 @@
  * The abbr plugin dialog window definition.
  *
  * Created out of the CKEditor Plugin SDK:
- * http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_sample_1
+ * https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample_1.html
  */
 
 // Our dialog definition.

--- a/tutorial-abbr-2/abbr/plugin.js
+++ b/tutorial-abbr-2/abbr/plugin.js
@@ -5,7 +5,7 @@
  * Basic sample plugin inserting abbreviation elements into the CKEditor editing area.
  *
  * Created out of the CKEditor Plugin SDK:
- * http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_sample_1
+ * https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample_1.html
  */
 
 // Register the plugin within the editor.
@@ -34,7 +34,7 @@ CKEDITOR.plugins.add( 'abbr', {
 		});
 
 		if ( editor.contextMenu ) {
-			
+
 			// Add a context menu group with the Edit Abbreviation item.
 			editor.addMenuGroup( 'abbrGroup' );
 			editor.addMenuItem( 'abbrItem', {

--- a/tutorial-abbr-2/abbr/samples/abbr.html
+++ b/tutorial-abbr-2/abbr/samples/abbr.html
@@ -17,7 +17,7 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 
 	<p>
 		This sample demonstrates the <strong>Abbreviation</strong> plugin that was created in the
-		<a href="http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_sample_2">second installment</a> of
+		<a href="https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample_2.html">second installment</a> of
 		of the CKEditor plugin tutorial series.
 	</p>
 
@@ -29,8 +29,8 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 	</p>
 
 	<p>
-		<strong>Note:</strong> This version of the Abbreviation plugin was built upon the source code created in the 
-		<a href="http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_sample_1">first part of the plugin tutorial</a> and was
+		<strong>Note:</strong> This version of the Abbreviation plugin was built upon the source code created in the
+		<a href="https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample_1.html">first part of the plugin tutorial</a> and was
 		extended with context menu support as well as the possibility to edit a previously inserted element.
 	</p>
 

--- a/tutorial-abbr-acf/abbr/dialogs/abbr.js
+++ b/tutorial-abbr-acf/abbr/dialogs/abbr.js
@@ -5,7 +5,7 @@
  * The abbr plugin dialog window definition.
  *
  * Created out of the CKEditor Plugin SDK:
- * http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_sample_1
+ * https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample_1.html
  */
 
 // Our dialog definition.

--- a/tutorial-abbr-acf/abbr/plugin.js
+++ b/tutorial-abbr-acf/abbr/plugin.js
@@ -5,7 +5,7 @@
  * Basic sample plugin inserting abbreviation elements into the CKEditor editing area.
  *
  * Created out of the CKEditor Plugin SDK:
- * http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_sample_1
+ * https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample_1.html
  */
 
 // Register the plugin within the editor.
@@ -47,7 +47,7 @@ CKEDITOR.plugins.add( 'abbr', {
 		});
 
 		if ( editor.contextMenu ) {
-			
+
 			// Add a context menu group with the Edit Abbreviation item.
 			editor.addMenuGroup( 'abbrGroup' );
 			editor.addMenuItem( 'abbrItem', {

--- a/tutorial-abbr-acf/abbr/samples/abbr.html
+++ b/tutorial-abbr-acf/abbr/samples/abbr.html
@@ -16,9 +16,9 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 	</h1>
 
 	<p>
-		This sample demonstrates the integration of <a href="http://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_acf">Advanced Content Filter (ACF)</a>
+		This sample demonstrates the integration of <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/dev_acf.html">Advanced Content Filter (ACF)</a>
 		with a custom <strong>Abbreviation</strong> plugin, as explained in the
-		<a href="http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_integration_with_acf">Integrating Plugins with Advanced Content Filter</a>
+		<a href="https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_integration_with_acf.html">Integrating Plugins with Advanced Content Filter</a>
 		article.
 	</p>
 

--- a/tutorial-autotag/autotag/plugin.js
+++ b/tutorial-autotag/autotag/plugin.js
@@ -2,8 +2,8 @@
  * Copyright (c) 2014-2018, CKSource - Frederico Knabben. All rights reserved.
  * Licensed under the terms of the MIT License (see LICENSE.md).
  *
- * Simple CKEditor tag autocomple that was built in the
- * https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_autocomplete.html tutorial.
+ * Simple CKEditor tag autocomplete that was built in the
+ * https://ckeditor.com/docs/ckeditor4/latest/features/autocomplete.html tutorial.
  */
 
 // Register the plugin in the editor.
@@ -193,7 +193,7 @@ CKEDITOR.plugins.add( 'autotag', {
 
 			// Define the templates of the autocomplete suggestions dropdown and output text.
 			config.itemTemplate = '<li data-id="{id}" class="issue-{type}">#{id}: {name}</li>';
-			config.outputTemplate = '<a href="https://github.com/ckeditor/ckeditor-dev/issues/{id}">{name} (#{id})</a> ';
+			config.outputTemplate = '<a href="https://github.com/ckeditor/ckeditor4/issues/{id}">{name} (#{id})</a> ';
 
 			// Attach autocomplete to the editor.
 			new CKEDITOR.plugins.autocomplete( editor, config );

--- a/tutorial-autotag/autotag/samples/autotag.html
+++ b/tutorial-autotag/autotag/samples/autotag.html
@@ -60,7 +60,7 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 
 	<p>
 		This sample demonstrates the <strong>Autotag</strong> plugin that was built in the
-		<a href="https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_autocomplete.html">Autocomplete</a> tutorial.
+		<a href="https://ckeditor.com/docs/ckeditor4/latest/features/autocomplete.html">Autocomplete</a> tutorial.
 	</p>
 
 	<p>

--- a/tutorial-simplebox-1/simplebox/plugin.js
+++ b/tutorial-simplebox-1/simplebox/plugin.js
@@ -5,7 +5,7 @@
  * Simple CKEditor Widget (Part 1).
  *
  * Created out of the CKEditor Widget SDK:
- * https://docs.ckeditor.com/ckeditor4/docs/#!/guide/widget_sdk_tutorial_1
+ * https://ckeditor.com/docs/ckeditor4/latest/guide/widget_sdk_tutorial_1.html
  */
 
 // Register the plugin within the editor.
@@ -23,8 +23,8 @@ CKEDITOR.plugins.add( 'simplebox', {
 		editor.widgets.add( 'simplebox', {
 			// Allow all HTML elements and classes that this widget requires.
 			// Read more about the Advanced Content Filter here:
-			// * https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_advanced_content_filter
-			// * https://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_integration_with_acf
+			// * https://ckeditor.com/docs/ckeditor4/latest/guide/dev_advanced_content_filter.html
+			// * https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_integration_with_acf.html
 			allowedContent: 'div(!simplebox); div(!simplebox-content); h2(!simplebox-title)',
 
 			// Minimum HTML which is required by this widget to work.
@@ -65,7 +65,7 @@ CKEDITOR.plugins.add( 'simplebox', {
 
 			// Check the elements that need to be converted to widgets.
 			//
-			// Note: The "element" argument is an instance of http://docs.ckeditor.com/#!/api/CKEDITOR.htmlParser.element
+			// Note: The "element" argument is an instance of https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_htmlParser_element.html
 			// so it is not a real DOM element yet. This is caused by the fact that upcasting is performed
 			// during data processing which is done on DOM represented by JavaScript objects.
 			upcast: function( element ) {

--- a/tutorial-simplebox-2/simplebox/plugin.js
+++ b/tutorial-simplebox-2/simplebox/plugin.js
@@ -5,7 +5,7 @@
  * Simple CKEditor Widget (Part 2).
  *
  * Created out of the CKEditor Widget SDK:
- * http://docs.ckeditor.com/ckeditor4/docs/#!/guide/widget_sdk_tutorial_2
+ * https://ckeditor.com/docs/ckeditor4/latest/guide/widget_sdk_tutorial_2.html
  */
 
 // Register the plugin within the editor.
@@ -26,8 +26,8 @@ CKEDITOR.plugins.add( 'simplebox', {
 		editor.widgets.add( 'simplebox', {
 			// Allow all HTML elements, classes, and styles that this widget requires.
 			// Read more about the Advanced Content Filter here:
-			// * http://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_advanced_content_filter
-			// * http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_integration_with_acf
+			// * https://ckeditor.com/docs/ckeditor4/latest/guide/dev_advanced_content_filter.html
+			// * https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_integration_with_acf.html
 			allowedContent:
 				'div(!simplebox,align-left,align-right,align-center){width};' +
 				'div(!simplebox-content); h2(!simplebox-title)',
@@ -74,7 +74,7 @@ CKEDITOR.plugins.add( 'simplebox', {
 
 			// Check the elements that need to be converted to widgets.
 			//
-			// Note: The "element" argument is an instance of http://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.htmlParser.element
+			// Note: The "element" argument is an instance of https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_htmlParser_element.html
 			// so it is not a real DOM element yet. This is caused by the fact that upcasting is performed
 			// during data processing which is done on DOM represented by JavaScript objects.
 			upcast: function( element ) {

--- a/tutorial-timestamp/timestamp/plugin.js
+++ b/tutorial-timestamp/timestamp/plugin.js
@@ -5,7 +5,7 @@
  * Basic sample plugin inserting current date and time into the CKEditor editing area.
  *
  * Created out of the CKEditor Plugin SDK:
- * http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_intro
+ * https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_intro.html
  */
 
 // Register the plugin within the editor.

--- a/tutorial-timestamp/timestamp/samples/timestamp.html
+++ b/tutorial-timestamp/timestamp/samples/timestamp.html
@@ -17,8 +17,8 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 
 	<p>
 		This sample demonstrates the <strong>Timestamp</strong> plugin that was built in the
-		<a href="http://docs.ckeditor.com/ckeditor4/docs/#!/guide/plugin_sdk_sample">Creating a CKEditor Plugin in 20 Lines of Code</a>
-		tutorial from the Plugin SDK section of the <a href="http://docs.ckeditor.com/ckeditor4/docs/#!/guide">CKEditor Developer's Guide</a>.
+		<a href="https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample.html">Creating a CKEditor Plugin in 20 Lines of Code</a>
+		tutorial from the Plugin SDK section of the <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/index.html">CKEditor Developer's Guide</a>.
 	</p>
 
 	<p>


### PR DESCRIPTION
Part of the cleanup.

[Link](https://github.com/ckeditor/ckeditor4/issues/3518) to particular issue in CKEditor4 repo.

[Link](https://github.com/ckeditor/ckeditor4/issues/2793) to a broader discussion after rename.