### PR TITLE
Remove flash plugin from samples

### DIFF
--- a/tutorial-abbr-1/abbr/samples/abbr.html
+++ b/tutorial-abbr-1/abbr/samples/abbr.html
@@ -60,7 +60,7 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 				{ name: 'styles' },
 				{ name: 'about' }
 			],
-			removePlugins: 'font,iframe,pagebreak,flash,stylescombo,print,preview,save,smiley,pastetext,pastefromword',
+			removePlugins: 'font,iframe,pagebreak,stylescombo,print,preview,save,smiley,pastetext,pastefromword',
 			removeButtons: 'Anchor,Font,Strike,Subscript,Superscript'
 		} );
 

--- a/tutorial-abbr-2/abbr/samples/abbr.html
+++ b/tutorial-abbr-2/abbr/samples/abbr.html
@@ -61,7 +61,7 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 				{ name: 'styles' },
 				{ name: 'about' }
 			],
-			removePlugins: 'font,iframe,pagebreak,flash,stylescombo,print,preview,save,smiley,pastetext,pastefromword',
+			removePlugins: 'font,iframe,pagebreak,stylescombo,print,preview,save,smiley,pastetext,pastefromword',
 			removeButtons: 'Anchor,Font,Strike,Subscript,Superscript'
 		} );
 

--- a/tutorial-abbr-acf/abbr/samples/abbr.html
+++ b/tutorial-abbr-acf/abbr/samples/abbr.html
@@ -60,7 +60,7 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 				{ name: 'styles' },
 				{ name: 'about' }
 			],
-			removePlugins: 'font,iframe,pagebreak,flash,stylescombo,print,preview,save,smiley,pastetext,pastefromword',
+			removePlugins: 'font,iframe,pagebreak,stylescombo,print,preview,save,smiley,pastetext,pastefromword',
 			removeButtons: 'Anchor,Font,Strike,Subscript,Superscript'
 		} );
 

--- a/tutorial-simplebox-1/simplebox/samples/simplebox.html
+++ b/tutorial-simplebox-1/simplebox/samples/simplebox.html
@@ -76,7 +76,7 @@ CKEDITOR.replace( 'editor1', {
 		{ name: 'styles' },
 		{ name: 'about' }
 	],
-	removePlugins: 'font,iframe,pagebreak,flash,stylescombo,print,preview,save,smiley,pastetext,pastefromword'
+	removePlugins: 'font,iframe,pagebreak,stylescombo,print,preview,save,smiley,pastetext,pastefromword'
 } );
 
 	</script>

--- a/tutorial-simplebox-2/simplebox/samples/simplebox.html
+++ b/tutorial-simplebox-2/simplebox/samples/simplebox.html
@@ -76,7 +76,7 @@ CKEDITOR.replace( 'editor1', {
 		{ name: 'styles' },
 		{ name: 'about' }
 	],
-	removePlugins: 'font,iframe,pagebreak,flash,stylescombo,print,preview,save,smiley,pastetext,pastefromword'
+	removePlugins: 'font,iframe,pagebreak,stylescombo,print,preview,save,smiley,pastetext,pastefromword'
 } );
 
 	</script>

--- a/tutorial-timestamp/timestamp/samples/timestamp.html
+++ b/tutorial-timestamp/timestamp/samples/timestamp.html
@@ -48,7 +48,7 @@ Licensed under the terms of the MIT License (see LICENSE.md).
 				{ name: 'styles' },
 				{ name: 'about' }
 			],
-			removePlugins: 'font,iframe,pagebreak,flash,stylescombo,print,preview,save,smiley,pastetext,pastefromword',
+			removePlugins: 'font,iframe,pagebreak,stylescombo,print,preview,save,smiley,pastetext,pastefromword',
 			removeButtons: 'Anchor,Font,Strike,Subscript,Superscript'
 		} );
 


### PR DESCRIPTION
I've removed `flash` from samples due to removing it from `ckeditor4` repo since `v4.17.0` . 

We can wait with this, untill: ckeditor/ckeditor4#4867